### PR TITLE
feat: add clock0::logger class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ compile_commands.json
 
 # Ignore meson wrapdb downloads
 subprojects/googletest-*/
+subprojects/fmt-*/
 subprojects/packagecache/

--- a/meson.build
+++ b/meson.build
@@ -6,16 +6,21 @@ project('clock0', 'cpp',
   ])
 
 if get_option('exec')
-  # Production dependencies
+  # https://github.com/mirror/ncurses
   curses = dependency('ncursesw', required : true)
 endif
 
 if get_option('tests')
-  # Test dependencies
+  # https://github.com/google/googletest
   gtest_proj = subproject('gtest')
   gtest = gtest_proj.get_variable('gtest_dep')
   gtest_main = gtest_proj.get_variable('gtest_main_dep')
   gmock = gtest_proj.get_variable('gmock_dep')
 endif
+
+# https://github.com/fmtlib/fmt
+fmt_proj = subproject('fmt',
+  default_options : ['default_library=static'])
+fmt = fmt_proj.get_variable('fmt_dep')
 
 subdir('src')

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -1,6 +1,5 @@
 /*
- * Main entrypoint for the clock0 program, a task management command-line
- * utility.
+ * Various filesystem utilities.
  *
  * Copyright (C) 2023 Kevin Morris <kevr@0cost.org>
  *
@@ -17,20 +16,14 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#include "config.hpp"
-#include "tui/tui.hpp"
-#include <iostream>
-#include <string>
+#include "filesystem.hpp"
+#include <fmt/format.h>
+#include <unistd.h>
 using namespace clock0;
 
-int main()
+std::filesystem::path filesystem::make_tmpdir(void)
 {
-    // Initialize the root window
-    tui::init();
-
-    // Refresh `stdscr`
-    tui::refresh();
-
-    // End `stdscr`
-    return tui::end();
+    std::string tmpl("/tmp/clock0-XXXXXX");
+    mkdtemp(tmpl.data());
+    return tmpl;
 }

--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -1,6 +1,5 @@
 /*
- * Main entrypoint for the clock0 program, a task management command-line
- * utility.
+ * Various filesystem utilities.
  *
  * Copyright (C) 2023 Kevin Morris <kevr@0cost.org>
  *
@@ -17,20 +16,16 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#include "config.hpp"
-#include "tui/tui.hpp"
-#include <iostream>
-#include <string>
-using namespace clock0;
+#ifndef SRC_FILESYSTEM_HPP
+#define SRC_FILESYSTEM_HPP
 
-int main()
+#include <filesystem>
+
+namespace clock0::filesystem
 {
-    // Initialize the root window
-    tui::init();
 
-    // Refresh `stdscr`
-    tui::refresh();
+std::filesystem::path make_tmpdir(void);
 
-    // End `stdscr`
-    return tui::end();
-}
+};
+
+#endif /* SRC_FILESYSTEM_HPP */

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -1,5 +1,5 @@
 /*
- * Main entrypoint unit tests for the clock0 executable.
+ * Logging tools.
  *
  * Copyright (C) 2023 Kevin Morris <kevr@0cost.org>
  *
@@ -16,13 +16,17 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#define main _main
-#include "main.cpp"
-#undef main
+#include "logging.hpp"
+using namespace clock0;
 
-#include "gtest/gtest.h"
+bool logger::debug_enabled = false;
 
-TEST(main, runs)
+void logger::set_global_debug(bool enabled)
 {
-    EXPECT_EQ(_main(), 0);
+    debug_enabled = enabled;
+}
+
+void logger::set_debug(bool enabled)
+{
+    m_debug = enabled;
 }

--- a/src/logging.hpp
+++ b/src/logging.hpp
@@ -1,0 +1,88 @@
+/*
+ * Logging tools.
+ *
+ * Copyright (C) 2023 Kevin Morris <kevr@0cost.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef SRC_LOGGING_HPP
+#define SRC_LOGGING_HPP
+
+#include "fmt/format.h"
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+
+namespace clock0
+{
+
+class logger
+{
+private:
+    static bool debug_enabled;
+    bool m_debug = debug_enabled;
+
+public:
+    template <typename... Args>
+    void info(const char *fmt, Args &&...args)
+    {
+        print(std::cout, "INFO", fmt, std::forward<Args>(args)...);
+    }
+
+    static void set_global_debug(bool);
+
+    void set_debug(bool);
+
+    template <typename... Args>
+    void debug(const char *fmt, Args &&...args)
+    {
+        if (m_debug) {
+            print(std::cout, "DBG ", fmt, std::forward<Args>(args)...);
+        }
+    }
+
+    template <typename... Args>
+    void error(const char *fmt, Args &&...args)
+    {
+        print(std::cerr, "ERR ", fmt, std::forward<Args>(args)...);
+    }
+
+private:
+    template <typename... Args>
+    void print(std::ostream &os, const char *label, const char *format,
+               Args &&...args)
+    {
+        // Build a local time point
+        auto now = std::chrono::system_clock::now();
+        auto time_point = std::chrono::system_clock::to_time_t(now);
+        auto *localtime = std::localtime(&time_point);
+
+        // Fill a stringstream with an fmt-formatted message
+        std::stringstream ss;
+        ss << std::put_time(localtime, "%Y-%m-%d %H:%M:%S %Z") << " [" << label
+           << "] "
+           << fmt::vformat(fmt::string_view(format),
+                           fmt::make_format_args(std::forward<Args>(args)...))
+           << std::endl;
+
+        // Write the stringstream's content to `os`
+        os << ss.str();
+    }
+};
+
+}; // namespace clock0
+
+#endif /* SRC_LOGGING_HPP */

--- a/src/logging.hpp
+++ b/src/logging.hpp
@@ -22,6 +22,8 @@
 #include "fmt/format.h"
 #include <chrono>
 #include <ctime>
+#include <filesystem>
+#include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
@@ -32,32 +34,57 @@ namespace clock0
 class logger
 {
 private:
+    static std::filesystem::path logfile; // Path to log file
     static bool debug_enabled;
+
+private:
+    std::ostream *cout = &std::cout; // Stdout stream
+    std::ostream *cerr = &std::cerr; // Stderr stream
+
+    std::ofstream logstream; // Optional log stream
+
     bool m_debug = debug_enabled;
 
 public:
+    //! Set a global logfile; new loggers will open a stream to it
+    static void set_global_logfile(const std::filesystem::path &);
+
+    //! Set a global debug flag; new loggers will match their debug flag
+    static void set_global_debug(bool);
+
+    static void init(void);
+
+public:
+    //! Construct a new logger
+    logger(void);
+
+    //! Reset stdout/stderr streams
+    void reset_streams(void);
+
+    //! Set the logger-specific stream to a log file
+    void set_logfile(const std::filesystem::path &);
+
+    //! Set the logger-specific debug flag
+    void set_debug(bool);
+
     template <typename... Args>
     void info(const char *fmt, Args &&...args)
     {
-        print(std::cout, "INFO", fmt, std::forward<Args>(args)...);
+        print(*cout, "INFO", fmt, std::forward<Args>(args)...);
     }
-
-    static void set_global_debug(bool);
-
-    void set_debug(bool);
 
     template <typename... Args>
     void debug(const char *fmt, Args &&...args)
     {
         if (m_debug) {
-            print(std::cout, "DBG ", fmt, std::forward<Args>(args)...);
+            print(*cout, "DBG ", fmt, std::forward<Args>(args)...);
         }
     }
 
     template <typename... Args>
     void error(const char *fmt, Args &&...args)
     {
-        print(std::cerr, "ERR ", fmt, std::forward<Args>(args)...);
+        print(*cerr, "ERR ", fmt, std::forward<Args>(args)...);
     }
 
 private:

--- a/src/logging.test.cpp
+++ b/src/logging.test.cpp
@@ -1,0 +1,98 @@
+/*
+ * Unit tests for logging.
+ *
+ * Copyright (C) 2023 Kevin Morris <kevr@0cost.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "logging.hpp"
+#include "string.hpp"
+#include "gtest/gtest.h"
+using namespace clock0;
+
+using testing::internal::CaptureStderr;
+using testing::internal::CaptureStdout;
+using testing::internal::GetCapturedStderr;
+using testing::internal::GetCapturedStdout;
+
+class logger_test : public testing::Test
+{
+protected:
+    logger log;
+};
+
+TEST_F(logger_test, info)
+{
+    CaptureStdout();
+    log.info("test {}", "format");
+
+    bool found =
+        search(GetCapturedStdout(), R"(.{10} .{8} .+ \[INFO\] test format)");
+    EXPECT_TRUE(found);
+}
+
+TEST_F(logger_test, timestamp)
+{
+    CaptureStdout();
+    log.info("test {}", "format");
+
+    bool found = search(
+        GetCapturedStdout(),
+        R"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \w+ \[INFO\] test format)");
+    EXPECT_TRUE(found);
+}
+
+TEST_F(logger_test, debug)
+{
+    // Enable debug for this particular logger
+    log.set_debug(true);
+
+    CaptureStdout();
+    log.debug("test {}", "format");
+
+    bool found =
+        search(GetCapturedStdout(), R"(.{10} .{8} .+ \[DBG \] test format)");
+    EXPECT_TRUE(found);
+
+    // But not for this one
+    logger not_debug_log;
+
+    CaptureStdout();
+    not_debug_log.debug("test {}", "format");
+
+    found =
+        search(GetCapturedStdout(), R"(.{10} .{8} .+ \[DBG \] test format)");
+    EXPECT_FALSE(found);
+
+    // But, if we set global debug, a new logger should debug log
+    logger::set_global_debug(true);
+    logger default_debug_log;
+
+    CaptureStdout();
+    default_debug_log.debug("test {}", "format");
+
+    found =
+        search(GetCapturedStdout(), R"(.{10} .{8} .+ \[DBG \] test format)");
+    EXPECT_TRUE(found);
+}
+
+TEST_F(logger_test, error)
+{
+    CaptureStderr();
+    log.error("test {}", "format");
+
+    bool found =
+        search(GetCapturedStderr(), R"(.{10} .{8} .+ \[ERR \] test format)");
+    EXPECT_TRUE(found);
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "config.hpp"
+#include "logging.hpp"
 #include "tui/tui.hpp"
 #include <iostream>
 #include <string>

--- a/src/meson.build
+++ b/src/meson.build
@@ -11,6 +11,7 @@ sources = [
   'tui/tui.cpp',
   'logging.cpp',
   'string.cpp',
+  'filesystem.cpp',
 ]
 
 if get_option('tests')

--- a/src/meson.build
+++ b/src/meson.build
@@ -9,6 +9,8 @@ configure_file(
 sources = [
   'ncurses.cpp',
   'tui/tui.cpp',
+  'logging.cpp',
+  'string.cpp',
 ]
 
 if get_option('tests')
@@ -19,25 +21,32 @@ if get_option('tests')
 
   # In-house static library for tests
   libclock0_test = static_library('clock0_test', sources,
+    dependencies : fmt,
     cpp_args : test_args)
   clock0_test = declare_dependency(link_with : libclock0_test)
 
   # C++ dependencies for test compilations
-  test_deps = [stubs, clock0_test, gtest, gtest_main, gmock]
+  test_deps = [fmt, stubs, clock0_test, gtest, gtest_main, gmock]
 
   main_test = executable('main.test', 'main.test.cpp',
     dependencies : test_deps,
     cpp_args : test_args)
   test('main.test', main_test)
+
+  logging_test = executable('logging.test', 'logging.test.cpp',
+    dependencies : test_deps,
+    cpp_args : test_args)
+  test('logging.test', logging_test)
 endif
 
 if get_option('exec')
   # In-house static library for executables
-  libclock0 = static_library('clock0', sources)
+  libclock0 = static_library('clock0', sources,
+    dependencies : fmt)
   clock0 = declare_dependency(link_with : libclock0)
 
   # C++ dependencies for executable compilations
-  exe_deps = [curses, clock0]
+  exe_deps = [fmt, curses, clock0]
 
   exe = executable('clock0', 'main.cpp',
     dependencies : exe_deps,

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -1,5 +1,5 @@
 /*
- * Main entrypoint unit tests for the clock0 executable.
+ * String utilities.
  *
  * Copyright (C) 2023 Kevin Morris <kevr@0cost.org>
  *
@@ -16,13 +16,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#define main _main
-#include "main.cpp"
-#undef main
+#include "string.hpp"
+using namespace clock0;
 
-#include "gtest/gtest.h"
-
-TEST(main, runs)
+bool clock0::search(const std::string &target, const char *regex_string)
 {
-    EXPECT_EQ(_main(), 0);
+    std::regex re(regex_string);
+    return std::regex_search(target, re);
 }

--- a/src/string.hpp
+++ b/src/string.hpp
@@ -1,5 +1,5 @@
 /*
- * Main entrypoint unit tests for the clock0 executable.
+ * String utilities.
  *
  * Copyright (C) 2023 Kevin Morris <kevr@0cost.org>
  *
@@ -16,13 +16,18 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#define main _main
-#include "main.cpp"
-#undef main
+#ifndef SRC_STRING_HPP
+#define SRC_STRING_HPP
 
-#include "gtest/gtest.h"
+#include <regex>
+#include <string>
 
-TEST(main, runs)
+namespace clock0
 {
-    EXPECT_EQ(_main(), 0);
-}
+
+//! Regex search of a string
+bool search(const std::string &, const char *);
+
+}; // namespace clock0
+
+#endif /* SRC_STRING_HPP */

--- a/subprojects/fmt.wrap
+++ b/subprojects/fmt.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = fmt-9.1.0
+source_url = https://github.com/fmtlib/fmt/archive/9.1.0.tar.gz
+source_filename = fmt-9.1.0.tar.gz
+source_hash = 5dea48d1fcddc3ec571ce2058e13910a0d4a6bab4cc09a809d8b1dd1c88ae6f2
+patch_filename = fmt_9.1.0-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/fmt_9.1.0-2/get_patch
+patch_hash = 23e8c4829f3e63f509b5643fe6bb87cbed39eae9594c451b338475d14d051967
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/fmt_9.1.0-2/fmt-9.1.0.tar.gz
+wrapdb_version = 9.1.0-2
+
+[provide]
+fmt = fmt_dep


### PR DESCRIPTION
This addition also brings in third-party library `fmt` grabbed using meson's wrapdb.