### PR TITLE
[Draft] Implement use of boost::program_options

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,6 +27,7 @@ jobs:
           sudo apt-get -y update
           sudo apt-get -y install git
           sudo apt-get -y install ccache gcc meson pkg-config
+          sudo apt-get -y install libboost-program-options-dev
           sudo apt-get -y install libncurses-dev
           mkdir -p ${SOURCE}
           cp --force -v /var/cache/apt/archives/*.deb ${SOURCE}/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,6 +27,7 @@ jobs:
           sudo apt-get -y update
           sudo apt-get -y install git
           sudo apt-get -y install ccache gcc meson pkg-config gcovr lcov
+          sudo apt-get -y install libboost-program-options-dev
           sudo apt-get -y install libncurses-dev
           mkdir -p ${SOURCE}
           cp --force -v /var/cache/apt/archives/*.deb ${SOURCE}/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ A command-line task manager that interfaces with web-based VCS
 
 ## Building
 
-Dependencies: C++17 compiler, [ncursesw](https://github.com/mirror/ncurses)
+Dependencies: C++17 compiler, [ncursesw](https://github.com/mirror/ncurses),
+[boost/program_options](https://github.com/boostorg/boost/tree/master/libs)
 
 This project relies on the [meson](https://mesonbuild.com/) build system to
 configure and build its executables and tests.

--- a/gcovr.cfg
+++ b/gcovr.cfg
@@ -1,0 +1,2 @@
+# Exclude subproject dependencies from coverage.
+exclude = subprojects/

--- a/meson.build
+++ b/meson.build
@@ -23,4 +23,9 @@ fmt_proj = subproject('fmt',
   default_options : ['default_library=static'])
 fmt = fmt_proj.get_variable('fmt_dep')
 
+# https://github.com/boostorg/boost
+boost_po = dependency('boost',
+  modules : ['program_options'],
+  required : true)
+
 subdir('src')

--- a/src/enums.hpp
+++ b/src/enums.hpp
@@ -1,0 +1,32 @@
+/*
+ * Program configuration for the clock0 program.
+ *
+ * Copyright (C) 2023 Kevin Morris <kevr@0cost.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef SRC_ENUMS_HPP
+#define SRC_ENUMS_HPP
+
+namespace clock0
+{
+
+// Program return codes
+enum return_codes : int {
+    SUCCESS = 0,
+};
+
+}; // namespace clock0
+
+#endif /* SRC_ENUMS_HPP */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,13 +18,51 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "config.hpp"
+#include "enums.hpp"
+#include "logging.hpp"
+#include "options.hpp"
 #include "tui/tui.hpp"
+#include <boost/program_options/errors.hpp>
 #include <iostream>
 #include <string>
 using namespace clock0;
 
-int main()
+void add_program_options(options &opt)
 {
+    opt.add("verbose,v", "enable verbose logging");
+    opt.add("log,l",
+            boost::program_options::value<std::string>()->composing(),
+            "path to logfile");
+}
+
+int main(int argc, char *argv[])
+{
+    options opt;
+    add_program_options(opt);
+
+    auto parse_cmdline = [&opt, argc, &argv] {
+        opt.parse_args(argc, argv);
+    };
+    if (!parse_args(parse_cmdline)) {
+        return OPT_CMDLINE_ERROR;
+    }
+
+    if (opt.exists("help")) {
+        std::cout << opt << std::endl;
+        return SUCCESS;
+    }
+
+    if (opt.exists("config")) {
+        auto conf_path = opt.get<std::string>("config");
+
+        auto parse_config = [&opt, &conf_path] {
+            opt.parse_args(conf_path);
+        };
+        if (!parse_args(parse_config)) {
+            return OPT_CONFIG_ERROR;
+        }
+    }
+
     // Initialize the root window
     tui::init();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,8 +68,13 @@ int main(int argc, char *argv[])
         logger::set_global_logfile(log_path);
     }
 
+    if (opt.exists("verbose")) {
+        logger::set_global_debug(true);
+    }
+
     logger log;
     log.info("started");
+    log.debug("verbose logging enabled");
 
     // Initialize the root window
     tui::init();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,6 +63,14 @@ int main(int argc, char *argv[])
         }
     }
 
+    if (opt.exists("log")) {
+        auto log_path = opt.get<std::string>("log");
+        logger::set_global_logfile(log_path);
+    }
+
+    logger log;
+    log.info("started");
+
     // Initialize the root window
     tui::init();
 

--- a/src/main.test.cpp
+++ b/src/main.test.cpp
@@ -21,6 +21,7 @@
 #undef main
 
 #include "filesystem.hpp"
+#include "string.hpp"
 #include "gtest/gtest.h"
 using namespace clock0;
 
@@ -98,4 +99,18 @@ TEST_F(main_test, config_error)
 
     MAKE_ARGS(2, "--config", conf_path.c_str());
     EXPECT_EQ(_main(argc, argv), SUCCESS);
+}
+
+TEST_F(main_test, log)
+{
+    auto log_path = tmpdir / "clock0.log";
+
+    MAKE_ARGS(2, "--log", log_path.c_str());
+    EXPECT_EQ(_main(argc, argv), SUCCESS);
+
+    std::ifstream ifs(log_path.c_str(), std::ios::in);
+    std::string line;
+    std::getline(ifs, line);
+    ifs.close();
+    EXPECT_TRUE(search(line, "started"));
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -26,6 +26,7 @@ sources = [
   'logging.cpp',
   'string.cpp',
   'filesystem.cpp',
+  'options.cpp',
 ]
 
 # Shared third-party dependencies

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,3 +1,17 @@
+#
+# Dependencies in this file are split between test and production
+# executables. Some dependencies are shared, while others are specific
+# to their executable compilation.
+#
+# `tp_deps` contains shared third-party dependencies
+#
+# If get_option('tests') is true, `tp_test_deps` is populated
+# with all third-party test dependencies (including stubs)
+#
+# If get_option('exec') is true, `tp_exe_deps` is populated
+# with all real third-party dependencies
+#
+
 conf = configuration_data()
 conf.set('name', 'clock0')
 conf.set('version', get_option('version'))
@@ -14,6 +28,9 @@ sources = [
   'filesystem.cpp',
 ]
 
+# Shared third-party dependencies
+tp_deps = [fmt, boost_po]
+
 if get_option('tests')
   subdir('stubs')
 
@@ -26,8 +43,12 @@ if get_option('tests')
     cpp_args : test_args)
   clock0_test = declare_dependency(link_with : libclock0_test)
 
-  # C++ dependencies for test compilations
-  test_deps = [fmt, stubs, clock0_test, gtest, gtest_main, gmock]
+  # Third-party (and stubbed) test dependencies
+  gtest_deps = [gtest, gtest_main, gmock]
+  tp_test_deps = [stubs] + tp_deps + gtest_deps
+
+  # All test dependencies
+  test_deps = [clock0_test] + tp_test_deps
 
   main_test = executable('main.test', 'main.test.cpp',
     dependencies : test_deps,
@@ -46,10 +67,10 @@ if get_option('exec')
     dependencies : fmt)
   clock0 = declare_dependency(link_with : libclock0)
 
-  # C++ dependencies for executable compilations
-  exe_deps = [fmt, curses, clock0]
+  # Third-party executable dependencies
+  tp_exe_deps = tp_deps + [curses]
 
   exe = executable('clock0', 'main.cpp',
-    dependencies : exe_deps,
+    dependencies : [clock0] + tp_exe_deps,
     install : true)
 endif

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1,0 +1,126 @@
+/*
+ * Program command-line and configuration file options.
+ *
+ * Copyright (C) 2023 Kevin Morris <kevr@0cost.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "options.hpp"
+#include "config.hpp"
+#include <boost/program_options/options_description.hpp>
+#include <boost/program_options/variables_map.hpp>
+using namespace clock0;
+
+std::ostream &options::usage(std::ostream &os) const
+{
+    boost::program_options::options_description desc;
+    desc.add(m_cmdline).add(m_config);
+    const auto &opts = desc.options();
+
+    std::vector<char> simple;
+    std::vector<std::string> params;
+
+    for (auto &opt : opts) {
+        char short_name = opt->long_name()[0];
+        auto param = opt->format_parameter();
+        if (param.size()) {
+            params.emplace_back("[-" + std::string(1, short_name) + " " +
+                                param + "]");
+        } else {
+            simple.emplace_back(opt->long_name()[0]);
+        }
+    }
+
+    os << "usage: " << PROG << " [-";
+    for (auto short_name : simple) {
+        os << short_name;
+    }
+    os << "]";
+
+    if (params.size()) {
+        for (auto &param : params) {
+            os << " " << param;
+        }
+    }
+    os << std::endl;
+
+    return os;
+}
+
+options::options(void)
+{
+    m_cmdline.add_options()("help,h", "print a help summary")(
+        "config,c",
+        boost::program_options::value<std::string>(),
+        "specify a configuration file");
+}
+
+void options::add(const char *arg, const char *help)
+{
+    m_config.add_options()(arg, help);
+}
+
+void options::add(const char *arg,
+                  const boost::program_options::value_semantic *value,
+                  const char *help)
+{
+    m_config.add_options()(arg, value, help);
+}
+
+void options::parse_args(int argc, char *argv[])
+{
+    m_argc = argc;
+    m_argv = const_cast<char **>(argv);
+
+    boost::program_options::options_description desc;
+    desc.add(m_cmdline).add(m_config);
+
+    // Parse the command-line with both m_cmdline and m_config options.
+    boost::program_options::store(
+        boost::program_options::parse_command_line(m_argc, m_argv, desc),
+        m_store);
+}
+
+void options::parse_args(const std::filesystem::path &path)
+{
+    boost::program_options::options_description desc;
+    desc.add(m_config);
+
+    // Parse the configuration file provided.
+    boost::program_options::store(
+        boost::program_options::parse_config_file(path.c_str(), desc),
+        m_store);
+
+    // Parse the command-line again; this is done to prioritize
+    // CLI arguments over configuration.
+    parse_args(m_argc, m_argv);
+}
+
+bool options::exists(const char *key)
+{
+    return m_store.count(key);
+}
+
+std::ostream &clock0::operator<<(std::ostream &os, const options &opt)
+{
+    opt.usage(os);
+
+    os << "\ncommand-line options:\n" << opt.m_cmdline;
+
+    if (opt.m_config.options().size()) {
+        os << "\nconfig options:\n" << opt.m_config;
+    }
+
+    return os;
+}

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -1,0 +1,99 @@
+/*
+ * Program command-line and configuration file options.
+ *
+ * Copyright (C) 2023 Kevin Morris <kevr@0cost.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef SRC_OPTIONS_HPP
+#define SRC_OPTIONS_HPP
+
+#include <boost/program_options.hpp>
+#include <boost/program_options/options_description.hpp>
+#include <filesystem>
+#include <iostream>
+
+namespace clock0
+{
+
+class options
+{
+private:
+    // A store of parsed program_options
+    boost::program_options::variables_map m_store;
+
+    // Option descriptions for both the command-line and configuration
+    boost::program_options::options_description m_cmdline;
+    boost::program_options::options_description m_config;
+
+    // Argument data
+    int m_argc = 0;
+    char **m_argv = nullptr;
+
+private:
+    std::ostream &usage(std::ostream &) const;
+
+public:
+    //! Default constructor
+    options(void);
+
+    //! Add a simple option with no value semantic
+    void add(const char *, const char *);
+
+    //! Add a value_semantic-based option
+    void add(const char *, const boost::program_options::value_semantic *,
+             const char *);
+
+    //! Parse command-line arguments
+    void parse_args(int, char *[]);
+
+    //! Parse a configuration file
+    void parse_args(const std::filesystem::path &);
+
+    //! Check if an option was given
+    bool exists(const char *);
+
+    //! Get the value of an option
+    template <typename T>
+    const T &get(const char *key)
+    {
+        return m_store.at(key).as<T>();
+    }
+
+    friend std::ostream &operator<<(std::ostream &, const options &);
+};
+
+std::ostream &operator<<(std::ostream &, const options &);
+
+enum options_errors : int {
+    OPT_CMDLINE_ERROR = 1,
+    OPT_CONFIG_ERROR = 2,
+};
+
+template <typename F>
+bool parse_args(F f)
+{
+    try {
+        f();
+    } catch (boost::program_options::error &e) {
+        std::cerr << "error: " << e.what() << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+}; // namespace clock0
+
+#endif /* SRC_OPTIONS_HPP */


### PR DESCRIPTION
This MR will contain basic program_options usage for configuring logs and printing out program information.