### PR TITLE
feat: tui::window, a child window class

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -80,6 +80,11 @@ void logger::set_debug(bool enabled)
     m_debug = enabled;
 }
 
+const std::string &logger::name(void) const
+{
+    return m_name;
+}
+
 void logger::set_name(const std::string &name)
 {
     m_name = name;

--- a/src/logging.hpp
+++ b/src/logging.hpp
@@ -72,6 +72,9 @@ public:
     //! Set the logger-specific debug flag
     void set_debug(bool);
 
+    //! Get the logger's name
+    const std::string &name(void) const;
+
     //! Set the logger's name
     void set_name(const std::string &);
 

--- a/src/main.test.cpp
+++ b/src/main.test.cpp
@@ -26,6 +26,7 @@
 #include "gtest/gtest.h"
 using namespace clock0;
 
+using testing::_;
 using testing::Return;
 using testing::internal::CaptureStdout;
 using testing::internal::GetCapturedStdout;
@@ -34,6 +35,8 @@ class main_test : public testing::Test
 {
 protected:
     WINDOW root;
+    WINDOW *container = new WINDOW;
+
     ncurses_mock nc;
     std::filesystem::path tmpdir;
 
@@ -64,6 +67,8 @@ protected:
     void mock_initscr(void)
     {
         EXPECT_CALL(nc, initscr()).WillRepeatedly(Return(&root));
+        EXPECT_CALL(nc, derwin(_, _, _, _, _))
+            .WillRepeatedly(Return(container));
     }
 
     void mock_getchar(void)

--- a/src/meson.build
+++ b/src/meson.build
@@ -24,6 +24,7 @@ sources = [
   'app.cpp',
   'ncurses.cpp',
   'tui/tui.cpp',
+  'tui/window.cpp',
   'tui/root_window.cpp',
   'tui/basic_window.cpp',
   'logging.cpp',
@@ -78,6 +79,11 @@ if get_option('tests')
     dependencies : test_deps,
     cpp_args : test_args)
   test('tui.root_window.test', tui_root_window_test)
+
+  tui_window_test = executable('tui.window.test', 'tui/window.test.cpp',
+    dependencies : test_deps,
+    cpp_args : test_args)
+  test('tui.window.test', tui_window_test)
 endif
 
 if get_option('exec')

--- a/src/mocks/ncurses.hpp
+++ b/src/mocks/ncurses.hpp
@@ -30,6 +30,8 @@ public:
     MOCK_METHOD(WINDOW *, initscr, (), (override));
     MOCK_METHOD(int, refresh, (), (override));
     MOCK_METHOD(int, getchar, (), (override));
+    MOCK_METHOD(WINDOW *, derwin, (WINDOW *, int, int, int, int), (override));
+    MOCK_METHOD(int, wrefresh, (WINDOW *), (override));
 };
 
 }; // namespace clock0

--- a/src/ncurses.cpp
+++ b/src/ncurses.cpp
@@ -55,6 +55,16 @@ int ncurses::getchar(void)
     return getch();
 }
 
+WINDOW *ncurses::derwin(WINDOW *win, int y, int x, int pos_y, int pos_x)
+{
+    return ::derwin(win, y, x, pos_y, pos_x);
+}
+
+int ncurses::wrefresh(WINDOW *win)
+{
+    return ::wrefresh(win);
+}
+
 void ncurses::get_maxyx(WINDOW *win, int &y, int &x)
 {
     getmaxyx(win, y, x);
@@ -63,6 +73,11 @@ void ncurses::get_maxyx(WINDOW *win, int &y, int &x)
 void ncurses::get_begyx(WINDOW *win, int &y, int &x)
 {
     getbegyx(win, y, x);
+}
+
+int ncurses::delwin(WINDOW *win)
+{
+    return ::delwin(win);
 }
 
 int ncurses::endwin(void)

--- a/src/ncurses.hpp
+++ b/src/ncurses.hpp
@@ -45,8 +45,11 @@ public:
     virtual int raw(void);
     virtual int refresh(void);
     virtual int getchar(void);
+    virtual WINDOW *derwin(WINDOW *, int, int, int, int);
+    virtual int wrefresh(WINDOW *);
     virtual void get_maxyx(WINDOW *, int &, int &);
     virtual void get_begyx(WINDOW *, int &, int &);
+    virtual int delwin(WINDOW *);
     virtual int endwin(void);
 };
 

--- a/src/ncurses.test.cpp
+++ b/src/ncurses.test.cpp
@@ -30,3 +30,21 @@ TEST(ncurses, getchar)
 {
     EXPECT_EQ(ncurses::ref().getchar(), 0);
 }
+
+TEST(ncurses, derwin)
+{
+    auto &nc = ncurses::ref();
+
+    // Initialize a fake WINDOW to be used as a parent
+    WINDOW root;
+
+    // Exercise derwin
+    auto win = nc.derwin(&root, 0, 0, 0, 0);
+    EXPECT_NE(win, nullptr);
+
+    // Exercise wrefresh
+    EXPECT_EQ(nc.wrefresh(win), OK);
+
+    // Exercise delwin
+    EXPECT_EQ(nc.delwin(win), OK);
+}

--- a/src/stubs/ncurses.cpp
+++ b/src/stubs/ncurses.cpp
@@ -55,6 +55,16 @@ int getch(void)
     return 0;
 }
 
+WINDOW *derwin(WINDOW *, int, int, int, int)
+{
+    return new WINDOW;
+}
+
+int wrefresh(WINDOW *)
+{
+    return OK;
+}
+
 void getmaxyx(WINDOW *, int &y, int &x)
 {
     x = TEST_COLS;
@@ -64,6 +74,12 @@ void getmaxyx(WINDOW *, int &y, int &x)
 void getbegyx(WINDOW *, int &y, int &x)
 {
     x = y = 0;
+}
+
+int delwin(WINDOW *win)
+{
+    delete win;
+    return OK;
 }
 
 int endwin(void)

--- a/src/stubs/ncurses.hpp
+++ b/src/stubs/ncurses.hpp
@@ -38,8 +38,11 @@ int keypad(WINDOW *, bool);
 int raw(void);
 int refresh(void);
 int getch(void);
+WINDOW *derwin(WINDOW *, int, int, int, int);
+int wrefresh(WINDOW *);
 void getmaxyx(WINDOW *, int &, int &);
 void getbegyx(WINDOW *, int &, int &);
+int delwin(WINDOW *);
 int endwin(void);
 
 #endif /* SRC_STUBS_NCURSES_HPP */

--- a/src/tui/basic_window.cpp
+++ b/src/tui/basic_window.cpp
@@ -17,6 +17,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "basic_window.hpp"
+#include <algorithm>
 using namespace clock0::tui;
 
 basic_window::basic_window(WINDOW *h)
@@ -27,6 +28,40 @@ basic_window::basic_window(WINDOW *h)
 WINDOW *basic_window::handle(void) const
 {
     return m_handle;
+}
+
+void basic_window::add_child(basic_window *c)
+{
+    log.debug("child added");
+    m_children.push_back(c);
+}
+
+void basic_window::pop_child(basic_window *c)
+{
+    auto it = std::find(m_children.begin(), m_children.end(), c);
+    m_children.erase(it);
+    log.debug("child popped");
+}
+
+std::list<basic_window *> basic_window::children(void) const
+{
+    return m_children;
+}
+
+void basic_window::draw(bool post_refresh)
+{
+    for (auto *c : m_children) {
+        c->draw(post_refresh);
+    }
+}
+
+int basic_window::refresh(void)
+{
+    for (auto *c : m_children) {
+        c->refresh();
+    }
+
+    return OK;
 }
 
 std::tuple<int, int> basic_window::size(void) const

--- a/src/tui/basic_window.hpp
+++ b/src/tui/basic_window.hpp
@@ -19,7 +19,9 @@
 #ifndef SRC_TUI_BASIC_WINDOW_HPP
 #define SRC_TUI_BASIC_WINDOW_HPP
 
+#include "../logging.hpp"
 #include "../ncurses.hpp"
+#include <list>
 #include <tuple>
 
 namespace clock0::tui
@@ -28,7 +30,14 @@ namespace clock0::tui
 class basic_window
 {
 protected:
+    // Ncurses window handle
     WINDOW *m_handle = nullptr;
+
+    // Children
+    std::list<basic_window *> m_children;
+
+    // basic_window logger
+    logger log { "basic_window" };
 
 public:
     /**
@@ -44,11 +53,20 @@ public:
     //! Returns a pointer to internal ncurses window handle
     WINDOW *handle(void) const;
 
+    //! Add a child window to the list of children
+    void add_child(basic_window *);
+
+    //! Remove a child window from the list of children
+    void pop_child(basic_window *);
+
+    //! Return a copy of the list of children
+    std::list<basic_window *> children(void) const;
+
     //! Pure virtual drawing of this window
-    virtual void draw(bool) = 0;
+    virtual void draw(bool post_refresh = false);
 
     //! Refresh this basic_window
-    virtual int refresh(void) = 0;
+    virtual int refresh(void);
 
     //! Returns an (x, y) tuple of the size of this window
     std::tuple<int, int> size(void) const;
@@ -56,6 +74,16 @@ public:
     //! Returns an (x, y) tuple of the position of this window
     std::tuple<int, int> position(void) const;
 };
+
+template <typename T>
+std::list<T *> list_to(const std::list<basic_window *> &children)
+{
+    std::list<T *> converted;
+    for (auto *w : children) {
+        converted.push_back(reinterpret_cast<T *>(w));
+    }
+    return converted;
+}
 
 }; // namespace clock0::tui
 

--- a/src/tui/root_window.cpp
+++ b/src/tui/root_window.cpp
@@ -55,12 +55,19 @@ root_window::~root_window(void)
 
 void root_window::draw(bool post_refresh)
 {
-    if (post_refresh) {
+    // Call draw on children; the root content
+    basic_window::draw(post_refresh);
+
+    // Refresh starting from this root window if we should
+    if (post_refresh)
         refresh();
-    }
 }
 
 int root_window::refresh(void)
 {
-    return ncurses::ref().refresh();
+    // Refresh `stdscr` window
+    ncurses::ref().refresh();
+
+    // Refresh children windows
+    return basic_window::refresh();
 }

--- a/src/tui/tui.cpp
+++ b/src/tui/tui.cpp
@@ -31,12 +31,25 @@ int tui::refresh(void)
 void tui::create(void)
 {
     root.reset();
+
+    // Create and refresh the root window
     root = std::make_unique<root_window>();
+    root->refresh();
+
+    // Spawn a container in the root window
+    container = std::make_shared<window>(*root, "container");
+    auto [x, y] = root->size();
+    container->create(x, y, 0, 0);
+
+    // Draw from the root
+    root->draw(true);
 }
 
 int tui::loop(void)
 {
     auto &nc = ncurses::ref();
+
+    // Main loop
     for (int ch = nc.getchar(); ch != 'q'; ch = nc.getchar()) {
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }

--- a/src/tui/tui.hpp
+++ b/src/tui/tui.hpp
@@ -21,6 +21,7 @@
 #define SRC_TUI_TUI_HPP
 
 #include "root_window.hpp"
+#include "window.hpp"
 #include <memory>
 
 namespace clock0::tui
@@ -35,6 +36,7 @@ class tui
 {
 private:
     std::unique_ptr<root_window> root;
+    std::shared_ptr<window> container;
 
 public:
     //! Initialize the root window of the TUI

--- a/src/tui/window.cpp
+++ b/src/tui/window.cpp
@@ -1,0 +1,92 @@
+/*
+ * A standard ncurses child window wrapper.
+ *
+ * Copyright (C) 2023 Kevin Morris <kevr@0cost.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "window.hpp"
+#include <stdexcept>
+using namespace clock0::tui;
+
+window::window(basic_window &parent, std::optional<std::string> name)
+    : basic_window(nullptr)
+{
+    log.set_name(name.value_or("window"));
+    log.debug("window constructed");
+
+    m_parent = &parent;
+    m_parent->add_child(this);
+}
+
+window::~window(void)
+{
+    m_parent->pop_child(this);
+
+    if (m_handle) {
+        ncurses::ref().delwin(m_handle);
+        m_handle = nullptr;
+    }
+
+    log.debug("window destructed");
+}
+
+basic_window &window::parent(void) const
+{
+    return *m_parent;
+}
+
+const std::string &window::name(void) const
+{
+    return log.name();
+}
+
+void window::set_name(const std::string &name)
+{
+    log.set_name(name);
+}
+
+void window::create(int x, int y, int pos_x, int pos_y)
+{
+    auto &nc = ncurses::ref();
+    m_handle = nc.derwin(m_parent->handle(), y, x, pos_y, pos_x);
+    if (!m_handle) {
+        throw std::runtime_error("unable to create a child window");
+    }
+}
+
+void window::draw(bool post_refresh)
+{
+    // Draw window details here
+    // For this base child window, this is no-op.
+    // Derivatives can call window::draw(post_refresh) to deal with
+    // post_refresh and graph traversal.
+
+    // Refresh if post_refresh was provided
+    if (post_refresh)
+        refresh();
+
+    // Use basic_window::draw to travel down the graph
+    basic_window::draw(post_refresh);
+}
+
+int window::refresh(void)
+{
+    log.info("refreshed");
+
+    if (int rc = ncurses::ref().wrefresh(m_handle))
+        return rc;
+
+    return basic_window::refresh();
+}

--- a/src/tui/window.hpp
+++ b/src/tui/window.hpp
@@ -1,5 +1,5 @@
 /*
- * Implementation of an ncurses root (stdscr) window
+ * A standard ncurses child window wrapper.
  *
  * Copyright (C) 2023 Kevin Morris <kevr@0cost.org>
  *
@@ -16,41 +16,54 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef SRC_TUI_ROOT_WINDOW_HPP
-#define SRC_TUI_ROOT_WINDOW_HPP
+#ifndef SRC_TUI_WINDOW_HPP
+#define SRC_TUI_WINDOW_HPP
 
 #include "../logging.hpp"
 #include "basic_window.hpp"
+#include <optional>
 
 namespace clock0::tui
 {
 
-class root_window : public basic_window
+class window : public basic_window
 {
 private:
-    static bool m_created;
+    basic_window *m_parent = nullptr;
 
-    // root_window log
-    logger log { "root_window" };
+    // window logger
+    logger log { "window" };
 
 public:
     /**
-     * Handle constructor
+     * Construct a child window
      *
-     * @param h External root ncurses (stdscr) window.
+     * @param parent Parent window
      */
-    root_window(void);
+    window(basic_window &, std::optional<std::string> name = std::nullopt);
 
-    //! Virtual destructor
-    virtual ~root_window(void);
+    //! Destruct this window
+    virtual ~window(void);
 
-    //! Draw the root_window
+    //! Return the internal parent
+    basic_window &parent(void) const;
+
+    //! Get the window logger's name
+    const std::string &name(void) const;
+
+    //! Set the window logger's name
+    void set_name(const std::string &);
+
+    //! Initialize this window
+    void create(int, int, int, int);
+
+    //! Draw this window's buffer
     void draw(bool post_refresh = false) override;
 
-    //! Refresh the root_window
+    //! Refresh this window
     int refresh(void) override;
 };
 
 }; // namespace clock0::tui
 
-#endif /* SRC_TUI_ROOT_WINDOW_HPP */
+#endif /* SRC_TUI_WINDOW_HPP */

--- a/src/tui/window.test.cpp
+++ b/src/tui/window.test.cpp
@@ -1,0 +1,113 @@
+/*
+ * Unit tests for the tui::window class
+ *
+ * Copyright (C) 2023 Kevin Morris <kevr@0cost.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "window.hpp"
+#include "../mocks/ncurses.hpp"
+#include "root_window.hpp"
+#include "gtest/gtest.h"
+using namespace clock0;
+using namespace clock0::tui;
+
+using testing::_;
+using testing::Return;
+
+class window_test : public testing::Test
+{
+protected:
+    ncurses_mock nc;
+
+    WINDOW root_handle;
+    WINDOW *container = new WINDOW;
+    std::unique_ptr<root_window> root;
+
+public:
+    void SetUp(void) override
+    {
+        ncurses::swap(nc);
+
+        EXPECT_CALL(nc, initscr()).WillRepeatedly(Return(&root_handle));
+
+        root = std::make_unique<root_window>();
+    }
+
+    void TearDown(void) override
+    {
+        ncurses::reset();
+    }
+};
+
+TEST_F(window_test, runs)
+{
+    window child(*root);
+    EXPECT_EQ(&child.parent(), root.get());
+}
+
+TEST_F(window_test, name)
+{
+    // Default construction
+    window child(*root);
+    EXPECT_EQ(child.name(), "window");
+
+    // Custom name construction
+    window child2(*root, "custom");
+    EXPECT_EQ(child2.name(), "custom");
+
+    // Change an existing window name
+    child.set_name("changed");
+    EXPECT_EQ(child.name(), "changed");
+}
+
+TEST_F(window_test, refreshes_from_root)
+{
+    EXPECT_CALL(nc, refresh()).WillRepeatedly(Return(OK));
+    EXPECT_CALL(nc, derwin(_, _, _, _, _)).WillOnce(Return(container));
+
+    window child(*root);
+
+    auto [x, y] = root->size();
+    child.create(x, y, 0, 0);
+
+    root->refresh();
+}
+
+TEST_F(window_test, children)
+{
+    window child(*root);
+
+    auto children = root->children();
+    EXPECT_EQ(children.size(), 1);
+}
+
+TEST_F(window_test, derwin_error)
+{
+    EXPECT_CALL(nc, derwin(_, _, _, _, _)).WillOnce(Return(nullptr));
+
+    window child(*root);
+    EXPECT_THROW(child.create(0, 0, 0, 0), std::runtime_error);
+}
+
+TEST_F(window_test, refresh_error)
+{
+    EXPECT_CALL(nc, derwin(_, _, _, _, _)).WillOnce(Return(container));
+
+    window child(*root);
+    EXPECT_NO_THROW(child.create(0, 0, 0, 0));
+
+    EXPECT_CALL(nc, wrefresh(_)).WillOnce(Return(ERR));
+    EXPECT_EQ(child.refresh(), ERR);
+}


### PR DESCRIPTION
The new tui::window class is used internally as a container within root_window. From here-on, the container introduced should be used as the root parent window.

Both draw() and refresh() traverse down the n-ary graph, performing both actions from left-to-right (list-wise). Any parent windows being refreshed will end up refreshing itself first, then all children underneath it. Those children will recurse the same operation.