### PR TITLE
change: keep project data related structs under project::data

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -120,7 +120,7 @@ int application::handle_program_args(void)
 
 int application::gather_project_data(void)
 {
-    project::data data;
+    project::data::parser data;
 
     auto [found, path] = create_project_data();
     if (!found) {
@@ -131,7 +131,7 @@ int application::gather_project_data(void)
     log.info("found '{}'", path.c_str());
     try {
         data.load(path);
-    } catch (project::data_error &e) {
+    } catch (project::data::data_error &e) {
         auto rel = std::filesystem::relative(path);
         std::cout << fmt::format("data error ('{}'): ", rel.c_str())
                   << e.what() << std::endl;

--- a/src/main.test.cpp
+++ b/src/main.test.cpp
@@ -301,7 +301,7 @@ TEST_F(cin_main_test, unable_to_create_data_file)
 
 TEST_F(main_test, data_error)
 {
-    auto data_path = tmpdir / project::DATA_FILE;
+    auto data_path = tmpdir / project::data::DEFAULT_DATA_FILE;
 
     {
         Json::Value root;

--- a/src/meson.build
+++ b/src/meson.build
@@ -28,8 +28,9 @@ sources = [
   'tui/root_window.cpp',
   'tui/basic_window.cpp',
   'project/project.cpp',
-  'project/validate.cpp',
   'project/data.cpp',
+  'project/data/parser.cpp',
+  'project/data/validate.cpp',
   'project/create.cpp',
   'logging.cpp',
   'string.cpp',
@@ -111,17 +112,17 @@ if get_option('tests')
     cpp_args : test_args)
   test('project.project.test', project_project_test)
 
-  project_data_test = executable('project.data.test',
-    'project/data.test.cpp',
+  project_data_parser_test = executable('project.data.parser.test',
+    'project/data/parser.test.cpp',
     dependencies : test_deps,
     cpp_args : test_args)
-  test('project.data.test', project_data_test)
+  test('project.data.parser.test', project_data_parser_test)
 
-  project_validate_test = executable('project.validate.test',
-    'project/validate.test.cpp',
+  project_data_validate_test = executable('project.data.validate.test',
+    'project/data/validate.test.cpp',
     dependencies : test_deps,
     cpp_args : test_args)
-  test('project.validate.test', project_validate_test)
+  test('project.data.validate.test', project_data_validate_test)
 endif
 
 if get_option('exec')

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -18,7 +18,7 @@
  */
 #include "options.hpp"
 #include "config.hpp"
-#include "project/data.hpp"
+#include "project/data/parser.hpp"
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/variables_map.hpp>
 using namespace clock0;
@@ -90,7 +90,7 @@ options::options(void)
         "specify a configuration file")(
         "file,f",
         boost::program_options::value<std::string>()->default_value(
-            project::DATA_FILE),
+            project::data::DEFAULT_DATA_FILE),
         "project data file");
 }
 

--- a/src/project/data.cpp
+++ b/src/project/data.cpp
@@ -18,34 +18,10 @@
  */
 #include "data.hpp"
 #include "../options.hpp"
-#include "validate.hpp"
 #include <filesystem>
 #include <fstream>
 #include <set>
 using namespace clock0::project;
-
-data::data(const std::filesystem::path &p)
-{
-    load(p);
-}
-
-void data::load(const std::filesystem::path &p)
-{
-    { // Scope out access to the file via ifstream
-        std::ifstream ifs(p.c_str(), std::ios::binary);
-        if (!ifs) {
-            throw data_missing_error("unable to load data file");
-        }
-        ifs >> *this;
-    }
-
-    // Validate project fields
-    validate_project(*this);
-
-    // Validate lists format, which recursively validates lists keys
-    Json::Value lists(this->operator[]("lists"));
-    validate_lists(lists);
-}
 
 std::tuple<bool, std::filesystem::path> clock0::project::discover_data(void)
 {

--- a/src/project/data/error.hpp
+++ b/src/project/data/error.hpp
@@ -1,5 +1,5 @@
 /*
- * Structures and utilities which aid with project data collection.
+ * Project data error structures.
  *
  * Copyright (C) 2023 Kevin Morris <kevr@0cost.org>
  *
@@ -16,26 +16,22 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef SRC_PROJECT_DATA_HPP
-#define SRC_PROJECT_DATA_HPP
+#ifndef SRC_PROJECT_DATA_ERROR_HPP
+#define SRC_PROJECT_DATA_ERROR_HPP
 
-#include "data/error.hpp"
-#include "data/parser.hpp"
-#include <filesystem>
-#include <string>
-#include <tuple>
+#include <stdexcept>
 
-namespace clock0::project
+namespace clock0::project::data
 {
 
-//! Discover a data file starting from the current directory up to root.
-std::tuple<bool, std::filesystem::path> discover_data(void);
+struct data_error : public std::domain_error {
+    using std::domain_error::domain_error;
+};
 
-//! Create new project data with no lists
-Json::Value create_data(const std::string &, unsigned int id = 0);
+struct data_missing_error : public data_error {
+    using data_error::data_error;
+};
 
-void ensure(bool, const char *);
+}; // namespace clock0::project::data
 
-}; // namespace clock0::project
-
-#endif /* SRC_PROJECT_DATA_HPP */
+#endif /* SRC_PROJECT_DATA_ERROR_HPP */

--- a/src/project/data/parser.cpp
+++ b/src/project/data/parser.cpp
@@ -1,0 +1,46 @@
+/*
+ * Declarations of a project parser parser class.
+ *
+ * Copyright (C) 2023 Kevin Morris <kevr@0cost.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "parser.hpp"
+#include "error.hpp"
+#include "validate.hpp"
+#include <fstream>
+using namespace clock0::project::data;
+
+parser::parser(const std::filesystem::path &p)
+{
+    load(p);
+}
+
+void parser::load(const std::filesystem::path &p)
+{
+    { // Scope out access to the file via ifstream
+        std::ifstream ifs(p.c_str(), std::ios::binary);
+        if (!ifs) {
+            throw data_missing_error("unable to load parser file");
+        }
+        ifs >> *this;
+    }
+
+    // Validate project fields
+    validate_project(*this);
+
+    // Validate lists format, which recursively validates lists keys
+    Json::Value lists(this->operator[]("lists"));
+    validate_lists(lists);
+}

--- a/src/project/data/parser.hpp
+++ b/src/project/data/parser.hpp
@@ -1,6 +1,5 @@
 /*
- * Structures and utilities which aid with the 'lists' field of
- * project data.
+ * Declarations of a project data parser class.
  *
  * Copyright (C) 2023 Kevin Morris <kevr@0cost.org>
  *
@@ -17,19 +16,30 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef SRC_PROJECT_VALIDATE_HPP
-#define SRC_PROJECT_VALIDATE_HPP
+#ifndef SRC_PROJECT_DATA_PARSER_HPP
+#define SRC_PROJECT_DATA_PARSER_HPP
 
 #include "json/json.h"
+#include <filesystem>
 
-namespace clock0::project
+namespace clock0::project::data
 {
 
-void ensure(bool, const char *);
-void validate_project(const Json::Value &);
-void validate_lists(const Json::Value &);
-void validate_list(const Json::Value &);
+const std::string DEFAULT_DATA_FILE = ".clock0.json";
 
-}; // namespace clock0::project
+class parser : public Json::Value
+{
+public:
+    //! Default constructor
+    parser(void) = default;
 
-#endif /* SRC_PROJECT_LISTS_HPP */
+    //! Load a data file by construction
+    parser(const std::filesystem::path &);
+
+    //! Load a data file
+    void load(const std::filesystem::path &);
+};
+
+}; // namespace clock0::project::data
+
+#endif /* SRC_PROJECT_DATA_PARSER_HPP */

--- a/src/project/data/parser.test.cpp
+++ b/src/project/data/parser.test.cpp
@@ -16,11 +16,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#include "data.hpp"
-#include "../filesystem.hpp"
+#include "parser.hpp"
+#include "../../filesystem.hpp"
+#include "error.hpp"
 #include "gtest/gtest.h"
 #include <fstream>
 using namespace clock0;
+using namespace project::data;
 
 class data_test : public testing::Test
 {
@@ -32,7 +34,7 @@ public:
     void SetUp(void) override
     {
         tmpdir = filesystem::make_tmpdir();
-        data_path = tmpdir / project::DATA_FILE;
+        data_path = tmpdir / DEFAULT_DATA_FILE;
     }
 
     void TearDown(void) override
@@ -50,7 +52,7 @@ TEST_F(data_test, data_error)
         ofs << root;
     }
 
-    EXPECT_THROW((project::data(data_path)), project::data_error);
+    EXPECT_THROW((parser(data_path)), data_error);
 }
 
 TEST_F(data_test, name_missing)
@@ -63,7 +65,7 @@ TEST_F(data_test, name_missing)
         ofs << root;
     }
 
-    EXPECT_THROW((project::data(data_path)), project::data_error);
+    EXPECT_THROW((parser(data_path)), data_error);
 }
 
 TEST_F(data_test, id_missing)
@@ -76,7 +78,7 @@ TEST_F(data_test, id_missing)
         ofs << root;
     }
 
-    EXPECT_THROW((project::data(data_path)), project::data_error);
+    EXPECT_THROW((parser(data_path)), data_error);
 }
 
 TEST_F(data_test, lists_missing)
@@ -90,7 +92,7 @@ TEST_F(data_test, lists_missing)
         ofs << root;
     }
 
-    EXPECT_THROW((project::data(data_path)), project::data_error);
+    EXPECT_THROW((parser(data_path)), data_error);
 }
 
 TEST_F(data_test, lists_is_not_array)
@@ -105,10 +107,10 @@ TEST_F(data_test, lists_is_not_array)
         ofs << root;
     }
 
-    EXPECT_THROW((project::data(data_path)), project::data_error);
+    EXPECT_THROW((parser(data_path)), data_error);
 }
 
 TEST_F(data_test, data_missing)
 {
-    EXPECT_THROW((project::data(data_path)), project::data_missing_error);
+    EXPECT_THROW((parser(data_path)), data_missing_error);
 }

--- a/src/project/data/validate.cpp
+++ b/src/project/data/validate.cpp
@@ -18,18 +18,18 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "validate.hpp"
-#include "data.hpp"
+#include "error.hpp"
 #include <set>
-using namespace clock0;
+using namespace clock0::project;
 
-void project::ensure(bool predicate, const char *error)
+void data::ensure(bool predicate, const char *error)
 {
     if (!predicate) {
         throw data_error(error);
     }
 }
 
-void project::validate_project(const Json::Value &proj)
+void data::validate_project(const Json::Value &proj)
 {
     // Iterate over base keys once and collect them into a set for checks
     std::set<std::string> keys;
@@ -43,7 +43,7 @@ void project::validate_project(const Json::Value &proj)
     ensure(keys.find("lists") != keys.end(), "missing key 'lists'");
 }
 
-void project::validate_lists(const Json::Value &lists)
+void data::validate_lists(const Json::Value &lists)
 {
     ensure(lists.isArray(), "lists must be an Array");
 
@@ -52,7 +52,7 @@ void project::validate_lists(const Json::Value &lists)
     }
 }
 
-void project::validate_list(const Json::Value &list)
+void data::validate_list(const Json::Value &list)
 {
     ensure(list.isObject(), "list element must be an Object");
 

--- a/src/project/data/validate.hpp
+++ b/src/project/data/validate.hpp
@@ -1,5 +1,6 @@
 /*
- * Structures and utilities which aid with project data collection.
+ * Structures and utilities which aid with the 'lists' field of
+ * project data.
  *
  * Copyright (C) 2023 Kevin Morris <kevr@0cost.org>
  *
@@ -16,26 +17,19 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef SRC_PROJECT_DATA_HPP
-#define SRC_PROJECT_DATA_HPP
+#ifndef SRC_PROJECT_VALIDATE_HPP
+#define SRC_PROJECT_VALIDATE_HPP
 
-#include "data/error.hpp"
-#include "data/parser.hpp"
-#include <filesystem>
-#include <string>
-#include <tuple>
+#include "json/json.h"
 
-namespace clock0::project
+namespace clock0::project::data
 {
 
-//! Discover a data file starting from the current directory up to root.
-std::tuple<bool, std::filesystem::path> discover_data(void);
-
-//! Create new project data with no lists
-Json::Value create_data(const std::string &, unsigned int id = 0);
-
 void ensure(bool, const char *);
+void validate_project(const Json::Value &);
+void validate_lists(const Json::Value &);
+void validate_list(const Json::Value &);
 
-}; // namespace clock0::project
+}; // namespace clock0::project::data
 
-#endif /* SRC_PROJECT_DATA_HPP */
+#endif /* SRC_PROJECT_LISTS_HPP */

--- a/src/project/data/validate.test.cpp
+++ b/src/project/data/validate.test.cpp
@@ -17,9 +17,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "validate.hpp"
-#include "data.hpp"
+#include "error.hpp"
 #include "gtest/gtest.h"
-using namespace clock0;
+using namespace clock0::project::data;
 
 TEST(validate, missing_list_title)
 {
@@ -27,7 +27,7 @@ TEST(validate, missing_list_title)
     Json::Value lists(Json::arrayValue);
     lists.append(list);
 
-    EXPECT_THROW(project::validate_lists(lists), project::data_error);
+    EXPECT_THROW(validate_lists(lists), data_error);
 }
 
 TEST(validate, invalid_title)
@@ -38,7 +38,7 @@ TEST(validate, invalid_title)
     Json::Value lists(Json::arrayValue);
     lists.append(list);
 
-    EXPECT_THROW(project::validate_lists(lists), project::data_error);
+    EXPECT_THROW(validate_lists(lists), data_error);
 }
 
 TEST(validate, missing_list_tasks)
@@ -49,7 +49,7 @@ TEST(validate, missing_list_tasks)
     Json::Value lists(Json::arrayValue);
     lists.append(list);
 
-    EXPECT_THROW(project::validate_lists(lists), project::data_error);
+    EXPECT_THROW(validate_lists(lists), data_error);
 }
 
 TEST(validate, invalid_list_tasks)
@@ -61,5 +61,5 @@ TEST(validate, invalid_list_tasks)
     Json::Value lists(Json::arrayValue);
     lists.append(list);
 
-    EXPECT_THROW(project::validate_lists(lists), project::data_error);
+    EXPECT_THROW(validate_lists(lists), data_error);
 }


### PR DESCRIPTION
In addition, restructure the file organization of some structures and utilities for a bit more separation.